### PR TITLE
Add test page to Streamlit app

### DIFF
--- a/pages/4_Test.py
+++ b/pages/4_Test.py
@@ -1,0 +1,13 @@
+import streamlit as st
+import pandas as pd
+
+st.header("Page de test")
+st.write("Ceci est une page de test pour l'application.")
+
+# Exemple simple : afficher les 5 premières lignes du jeu de données principal
+try:
+    df = pd.read_csv("data/velos.csv")
+    st.subheader("Aperçu des données")
+    st.write(df.head())
+except Exception as e:
+    st.error(f"Erreur lors du chargement des données : {e}")


### PR DESCRIPTION
## Summary
- add a simple Streamlit page that displays the first rows of the dataset

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement streamlit)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68419f9f04348325bdaf014183c1650c